### PR TITLE
Unlock Doctrine 3.x for Contao 4.13+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/dependency-injection": "^4.4 || ^5.0",
         "symfony/event-dispatcher": "^4.4 || ^5.0",
         "symfony/http-kernel": "^4.4 || ^5.0",
-        "doctrine/dbal": "^2.11",
+        "doctrine/dbal": "^2.11 || ^3.0",
         "geoip2/geoip2": "~2.0"
     },
     "require-dev": {

--- a/src/EventListener/DcaLoaderListener.php
+++ b/src/EventListener/DcaLoaderListener.php
@@ -108,16 +108,16 @@ class DcaLoaderListener
 
     private function addHeaderInformation(string $table): void
     {
-        $previous = $GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'];
+        $previous = $GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'] ?? null;
 
         $GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'] = function (array $header) use ($previous, $table): array {
             $act = (string) Input::get('act');
             $ptable = $GLOBALS['TL_DCA'][$table]['config']['ptable'];
 
             if ('' === $act || 'select' === $act || ('paste' === $act && 'create' === Input::get('mode'))) {
-                $parent = $this->connection->fetchAssoc("SELECT * FROM $ptable WHERE id=?", [(int) Input::get('id')]);
+                $parent = $this->connection->fetchAssociative("SELECT * FROM $ptable WHERE id=?", [(int) Input::get('id')]);
             } elseif ('paste' === $act) {
-                $parent = $this->connection->fetchAssoc("SELECT * FROM $ptable WHERE id=(SELECT pid FROM $table WHERE id=?)", [(int) Input::get('id')]);
+                $parent = $this->connection->fetchAssociative("SELECT * FROM $ptable WHERE id=(SELECT pid FROM $table WHERE id=?)", [(int) Input::get('id')]);
             }
 
             if (!$parent) {


### PR DESCRIPTION
This PR adjusts this extension to allow Doctrine 3.x so that it can be installed in Contao 4.13. It also fixes an issue that occurs in PHP 8.