### PR TITLE
Lazy instantiation of `GeoIp2\Database\Reader`

### DIFF
--- a/src/CountryProvider.php
+++ b/src/CountryProvider.php
@@ -27,10 +27,6 @@ class CountryProvider
     {
         $this->reader = $reader;
         $this->fallbackCountry = $fallbackCountry;
-
-        if (null === $this->reader && !empty($_SERVER['GEOIP2_DATABASE'])) {
-            $this->reader = static fn() => new Reader($_SERVER['GEOIP2_DATABASE']);
-        }
     }
 
     /**
@@ -95,6 +91,10 @@ class CountryProvider
         }
 
         try {
+            if (null === $this->reader && !empty($_SERVER['GEOIP2_DATABASE'])) {
+                $this->reader = new Reader($_SERVER['GEOIP2_DATABASE']);
+            }
+
             return ($this->reader)()->country($request->getClientIp())->country->isoCode ?: $this->fallbackCountry;
         } catch (AddressNotFoundException $exception) {
             return $this->fallbackCountry;

--- a/src/DependencyInjection/Terminal42Geoip2CountryExtension.php
+++ b/src/DependencyInjection/Terminal42Geoip2CountryExtension.php
@@ -6,9 +6,11 @@ namespace Terminal42\Geoip2CountryBundle\DependencyInjection;
 
 use GeoIp2\Database\Reader;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Terminal42\Geoip2CountryBundle\CountryProvider;
 
@@ -27,8 +29,12 @@ class Terminal42Geoip2CountryExtension extends Extension
         $container->setParameter('terminal42_geoip2_country.database_path', $config['database_path']);
 
         if ($config['database_path']) {
-            $definition = $container->findDefinition(CountryProvider::class);
-            $definition->replaceArgument(0, new Definition(Reader::class, [$config['database_path']]));
+            $readerId = 'terminal42_geoip2_country.geoip_reader';
+            $container->setDefinition($readerId, new Definition(Reader::class, [$config['database_path']]));
+            $container
+                ->findDefinition(CountryProvider::class)
+                ->replaceArgument(0, new ServiceClosureArgument(new Reference($readerId)))
+            ;
         }
     }
 }


### PR DESCRIPTION
Currently `GeoIp2\Database\Reader` for the `CountryProvider` is always instantiated right away in the container. This unfortunately means you cannot update the database file within the same application - i.e. you cannot create your own GeoIP database update command within the App for example as the already existent `GeoIp2\Database\Reader` locks the file.

This PR introduces a lazy instantiation of the database reader.